### PR TITLE
Fix Class 2 documentation links to use full website URLs

### DIFF
--- a/class02/class02.md
+++ b/class02/class02.md
@@ -14,31 +14,31 @@ This class covers the fundamental numerical optimization techniques essential fo
 
 The class is structured around 1 slide deck and four interactive Jupyter notebooks:
 
-1. **[Part 1a: Root Finding & Backward Euler](part1_root_finding.html)**
+1. **[Part 1a: Root Finding & Backward Euler](https://learningtooptimize.github.io/LearningToControlClass/dev/class02/part1_root_finding.html)**
    - Root-finding algorithms for implicit integration
    - Fixed-point iteration vs. Newton's method
    - Application to pendulum dynamics
 
 
-2. **[Part 1b: Minimization via Newton's Method](part1_minimization.html)**
+2. **[Part 1b: Minimization via Newton's Method](https://learningtooptimize.github.io/LearningToControlClass/dev/class02/part1_minimization.html)**
    - Unconstrained optimization fundamentals
    - Newton's method implementation
    - Globalization strategies: Hessian matrix and regularization
 
-3. **[Part 2: Equality Constraints](part2_eq_constraints.html)**
+3. **[Part 2: Equality Constraints](https://learningtooptimize.github.io/LearningToControlClass/dev/class02/part2_eq_constraints.html)**
    - Lagrange multiplier theory
    - KKT conditions for equality constraints
    - Quadratic programming implementation
 
-4. **[Part 3: Interior-Point Methods](part3_ipm.html)**
+4. **[Part 3: Interior-Point Methods](https://learningtooptimize.github.io/LearningToControlClass/dev/class02/part3_ipm.html)**
    - Inequality constraint handling
    - Barrier methods and log-barrier functions
    - Comparison with penalty methods
 
 ## Additional Resources
 
-- **[Lecture Slides (PDF)](ISYE_8803___Lecture_2___Slides.pdf)** - Complete slide deck
-- **[LaTeX Source](main.tex)** - Source code for lecture slides
+- **[Lecture Slides (PDF)](https://learningtooptimize.github.io/LearningToControlClass/dev/class02/ISYE_8803___Lecture_2___Slides.pdf)** - Complete slide deck
+- **[LaTeX Source](https://learningtooptimize.github.io/LearningToControlClass/dev/class02/main.tex)** - Source code for lecture slides
 
 ## Key Learning Outcomes
 

--- a/class02/overview.md
+++ b/class02/overview.md
@@ -35,28 +35,28 @@ By the end of this class, students will be able to:
 The class is structured around four interactive Jupyter notebooks that build upon each other:
 
 
-1. **[Part 1a: Root Finding & Backward Euler](part1_root_finding.html)**
+1. **[Part 1a: Root Finding & Backward Euler](https://learningtooptimize.github.io/LearningToControlClass/dev/class02/part1_root_finding.html)**
    - Root-finding algorithms for implicit integration
    - Fixed-point iteration vs. Newton's method
    - Backward Euler implementation for ODEs
    - Convergence analysis and comparison
    - Application to pendulum dynamics
 
-2. **[Part 1b: Minimization via Newton's Method](part1_minimization.html)**
+2. **[Part 1b: Minimization via Newton's Method](https://learningtooptimize.github.io/LearningToControlClass/dev/class02/part1_minimization.html)**
    - Unconstrained optimization fundamentals
    - Newton's method for minimization
    - Hessian matrix and positive definiteness
    - Regularization and line search techniques
    - Practical implementation with Julia
 
-3. **[Part 2: Equality Constraints](part2_eq_constraints.html)**
+3. **[Part 2: Equality Constraints](https://learningtooptimize.github.io/LearningToControlClass/dev/class02/part2_eq_constraints.html)**
    - Lagrange multiplier theory
    - KKT conditions for equality constraints
    - Quadratic programming with equality constraints
    - Visualization of constrained optimization landscapes
    - Practical implementation examples
 
-4. **[Part 3: Interior-Point Methods](part3_ipm.ipynb)**
+4. **[Part 3: Interior-Point Methods](https://learningtooptimize.github.io/LearningToControlClass/dev/class02/part3_ipm.html)**
    - Inequality constraint handling
    - Barrier methods and log-barrier functions
    - Interior-point algorithm implementation
@@ -65,9 +65,9 @@ The class is structured around four interactive Jupyter notebooks that build upo
 
 ### Additional Resources
 
-- **[Lecture Slides (PDF)](ISYE_8803___Lecture_2___Slides.pdf)** - Complete slide deck from the presentation
-- **[LaTeX Source Files](main.tex)** - Source code for the lecture slides
-- **[Demo Script](penalty_barrier_demo.py)** - Python demonstration of penalty vs. barrier methods
+- **[Lecture Slides (PDF)](https://learningtooptimize.github.io/LearningToControlClass/dev/class02/ISYE_8803___Lecture_2___Slides.pdf)** - Complete slide deck from the presentation
+- **[LaTeX Source Files](https://learningtooptimize.github.io/LearningToControlClass/dev/class02/main.tex)** - Source code for the lecture slides
+- **[Demo Script](https://learningtooptimize.github.io/LearningToControlClass/dev/class02/penalty_barrier_demo.py)** - Python demonstration of penalty vs. barrier methods
 
 ## Key Concepts Covered
 


### PR DESCRIPTION
- Update class02.md to use full documentation website URLs for HTML notebooks
- Update overview.md to use full documentation website URLs for HTML notebooks
- Fix relative path links to point to proper documentation site
- Ensure all interactive materials are accessible from the course website

This fixes broken links in the Class 2 documentation by using absolute URLs instead of relative paths, making the materials properly accessible from the course documentation website.